### PR TITLE
Implemented redirects for old slugs

### DIFF
--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\EntityManager;
 use Netgen\Layouts\Contentful\Entity\ContentfulEntry;
 use Netgen\Layouts\Contentful\Exception\NotFoundException;
 use Netgen\Layouts\Contentful\Service\Contentful;
-use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\RedirectRoute;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
@@ -67,7 +67,7 @@ final class RoutesCommand extends Command
             try {
                 $contentfulEntry = $this->contentful->loadContentfulEntry($contentfulEntryId);
                 $this->contentful->deleteRedirects($contentfulEntry);
-                $io->writeln("All redirect routes deleted");
+                $io->writeln('All redirect routes deleted');
             } catch (NotFoundException $e) {
                 $io->writeln($e->getMessage());
             } catch (\Exception $e) {
@@ -84,22 +84,19 @@ final class RoutesCommand extends Command
 
         /** @var Route $route */
         foreach ($routes as $route) {
-
             $contentClass = explode(':', $route->getDefault('_content_id'))[0];
 
-            if ($contentClass == ContentfulEntry::class) {
+            if ($contentClass === ContentfulEntry::class) {
                 /** @var ContentfulEntry $content */
                 $content = $this->contentful->loadContentfulEntry($route->getName());
-                $status = "200";
-
-            } elseif ($contentClass == RedirectRoute::class) {
+                $status = '200';
+            } elseif ($contentClass === RedirectRoute::class) {
                 /** @var ContentfulEntry $content */
                 $content = $this->contentful->loadContentfulEntry(explode('_', $route->getName())[0]);
-                $status = "301";
+                $status = '301';
             }
 
-            $table->addRow([$content->getId(), $route->getId(), $route->getStaticPrefix(), $status, $content->getContentType()->getName(),$content->getName() ]);
-
+            $table->addRow([$content->getId(), $route->getId(), $route->getStaticPrefix(), $status, $content->getContentType()->getName(), $content->getName()]);
         }
         $table->render();
 

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -7,6 +7,7 @@ namespace Netgen\Bundle\LayoutsContentfulBundle\Command;
 use Doctrine\ORM\EntityManager;
 use Netgen\Layouts\Contentful\Entity\ContentfulEntry;
 use Netgen\Layouts\Contentful\Exception\NotFoundException;
+use Netgen\Layouts\Contentful\Exception\RuntimeException;
 use Netgen\Layouts\Contentful\Service\Contentful;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\RedirectRoute;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
@@ -62,8 +63,13 @@ final class RoutesCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         if ($input->getOption('delete') !== null) {
+            $entryId = $input->getOption('delete');
+            if (!is_string($entryId)) {
+                throw new RuntimeException('Redirects can only be deleted for a single entry per command run.');
+            }
+
             try {
-                $contentfulEntry = $this->contentful->loadContentfulEntry($input->getOption('delete'));
+                $contentfulEntry = $this->contentful->loadContentfulEntry($entryId);
                 $this->contentful->deleteRedirects($contentfulEntry);
                 $io->writeln('All redirect routes deleted');
             } catch (NotFoundException $e) {

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netgen\Bundle\LayoutsContentfulBundle\Command;
+
+use Doctrine\ORM\EntityManager;
+use Netgen\Layouts\Contentful\Entity\ContentfulEntry;
+use Netgen\Layouts\Contentful\Service\Contentful;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\RedirectRoute;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class RoutesCommand extends Command
+{
+    /**
+     * @var \Netgen\Layouts\Contentful\Service\Contentful
+     */
+    private $contentful;
+
+    /**
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $fileSystem;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $entityManager;
+
+    /**
+     * @var \Symfony\Component\Console\Style\SymfonyStyle
+     */
+    private $io;
+
+    public function __construct(Contentful $contentful, Filesystem $fileSystem, EntityManager $entityManager)
+    {
+        $this->contentful = $contentful;
+        $this->fileSystem = $fileSystem;
+        $this->entityManager = $entityManager;
+
+        // Parent constructor call is mandatory in commands registered as services
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Lists routes');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $table = new Table($output);
+        $table->setHeaders(['Code', 'URL', 'Content type', 'Content name']);
+
+        $routes = $this->entityManager->getRepository(Route::class)->findAll();
+
+        /** @var Route $route */
+        foreach ($routes as $route) {
+
+            $contentClass = explode(':', $route->getDefault('_content_id'))[0];
+
+            if ($contentClass == ContentfulEntry::class) {
+                /** @var ContentfulEntry $content */
+                $content = $this->contentful->loadContentfulEntry($route->getName());
+                $status = "200";
+
+            } elseif ($contentClass == RedirectRoute::class) {
+                /** @var ContentfulEntry $content */
+                $content = $this->contentful->loadContentfulEntry(explode('_', $route->getName())[0]);
+                $status = "301";
+            }
+
+            $table->addRow([$status, $route->getStaticPrefix(),$content->getContentType()->getName(),$content->getName() ]);
+
+        }
+        $table->render();
+
+        return 0;
+    }
+}

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -62,7 +62,7 @@ final class RoutesCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         if ($input->getOption('delete') !== null) {
-            $contentfulEntryId = (string) $input->getOption('delete');
+            $contentfulEntryId = (string) (is_array($input->getOption('delete')) ? $input->getOption('delete')[0] : $input->getOption('delete'));
 
             try {
                 $contentfulEntry = $this->contentful->loadContentfulEntry($contentfulEntryId);

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -62,10 +62,8 @@ final class RoutesCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         if ($input->getOption('delete') !== null) {
-            $contentfulEntryId = (string) (is_array($input->getOption('delete')) ? $input->getOption('delete')[0] : $input->getOption('delete'));
-
             try {
-                $contentfulEntry = $this->contentful->loadContentfulEntry($contentfulEntryId);
+                $contentfulEntry = $this->contentful->loadContentfulEntry($input->getOption('delete'));
                 $this->contentful->deleteRedirects($contentfulEntry);
                 $io->writeln('All redirect routes deleted');
             } catch (NotFoundException $e) {

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -87,14 +87,15 @@ final class RoutesCommand extends Command
             $contentClass = explode(':', $route->getDefault('_content_id'))[0];
 
             if ($contentClass === ContentfulEntry::class) {
-                /** @var ContentfulEntry $content */
-                $content = $this->contentful->loadContentfulEntry($route->getName());
+                $contentfulEntryId = $route->getName();
                 $status = '200';
             } elseif ($contentClass === RedirectRoute::class) {
-                /** @var ContentfulEntry $content */
-                $content = $this->contentful->loadContentfulEntry(explode('_', $route->getName())[0]);
+                $contentfulEntryId = explode('_', $route->getName())[0];
                 $status = '301';
             }
+            
+            /** @var ContentfulEntry $content */
+            $content = $this->contentful->loadContentfulEntry($contentfulEntryId);
 
             $table->addRow([$content->getId(), $route->getId(), $route->getStaticPrefix(), $status, $content->getContentType()->getName(), $content->getName()]);
         }

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -62,7 +62,7 @@ final class RoutesCommand extends Command
         $io = new SymfonyStyle($input, $output);
 
         if ($input->getOption('delete') !== null) {
-            $contentfulEntryId = $input->getOption('delete');
+            $contentfulEntryId = (string) $input->getOption('delete');
 
             try {
                 $contentfulEntry = $this->contentful->loadContentfulEntry($contentfulEntryId);
@@ -85,15 +85,14 @@ final class RoutesCommand extends Command
         /** @var Route $route */
         foreach ($routes as $route) {
             $contentClass = explode(':', $route->getDefault('_content_id'))[0];
+            $contentfulEntryId = $route->getName();
+            $status = '200';
 
-            if ($contentClass === ContentfulEntry::class) {
-                $contentfulEntryId = $route->getName();
-                $status = '200';
-            } elseif ($contentClass === RedirectRoute::class) {
+            if ($contentClass === RedirectRoute::class) {
                 $contentfulEntryId = explode('_', $route->getName())[0];
                 $status = '301';
             }
-            
+
             /** @var ContentfulEntry $content */
             $content = $this->contentful->loadContentfulEntry($contentfulEntryId);
 

--- a/bundle/Command/RoutesCommand.php
+++ b/bundle/Command/RoutesCommand.php
@@ -6,12 +6,14 @@ namespace Netgen\Bundle\LayoutsContentfulBundle\Command;
 
 use Doctrine\ORM\EntityManager;
 use Netgen\Layouts\Contentful\Entity\ContentfulEntry;
+use Netgen\Layouts\Contentful\Exception\NotFoundException;
 use Netgen\Layouts\Contentful\Service\Contentful;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\Route;
 use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Orm\RedirectRoute;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Filesystem\Filesystem;
@@ -50,13 +52,33 @@ final class RoutesCommand extends Command
 
     protected function configure(): void
     {
-        $this->setDescription('Lists routes');
+        $this
+            ->setDescription('Show routes and possibility to delete redirects')
+            ->addOption('delete', 'd', InputOption::VALUE_REQUIRED, 'Delete all redirects for given Entry ID');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('delete') !== null) {
+            $contentfulEntryId = $input->getOption('delete');
+
+            try {
+                $contentfulEntry = $this->contentful->loadContentfulEntry($contentfulEntryId);
+                $this->contentful->deleteRedirects($contentfulEntry);
+                $io->writeln("All redirect routes deleted");
+            } catch (NotFoundException $e) {
+                $io->writeln($e->getMessage());
+            } catch (\Exception $e) {
+                $io->writeln($e->getMessage());
+            }
+
+            return 0;
+        }
+
         $table = new Table($output);
-        $table->setHeaders(['Code', 'URL', 'Content type', 'Content name']);
+        $table->setHeaders(['Entry ID', 'URL', 'Status', 'Content type', 'Content name']);
 
         $routes = $this->entityManager->getRepository(Route::class)->findAll();
 
@@ -76,7 +98,7 @@ final class RoutesCommand extends Command
                 $status = "301";
             }
 
-            $table->addRow([$status, $route->getStaticPrefix(),$content->getContentType()->getName(),$content->getName() ]);
+            $table->addRow([$content->getId(), $route->getId(), $route->getStaticPrefix(), $status, $content->getContentType()->getName(),$content->getName() ]);
 
         }
         $table->render();

--- a/bundle/Command/SyncCommand.php
+++ b/bundle/Command/SyncCommand.php
@@ -55,19 +55,13 @@ final class SyncCommand extends Command
 
             $syncManager = $client->getSynchronizationManager();
 
-            $tokenPath = $this->contentful->getSpaceCachePath($client) . '/token';
-            if (!$this->fileSystem->exists($tokenPath)) {
-                $result = $syncManager->startSync();
-            } else {
-                $token = (string) file_get_contents($tokenPath);
-                $result = $syncManager->continueSync($token);
-            }
-
+            $result = $syncManager->startSync();
             $this->buildContentEntries($result->getItems());
 
-            if (!$result->isDone()) {
+            while (!$result->isDone()) {
                 $token = $result->getToken();
-                $this->fileSystem->dumpFile($tokenPath, $token);
+                $result = $syncManager->continueSync($token);
+                $this->buildContentEntries($result->getItems());
             }
         }
 

--- a/bundle/Controller/WebhookController.php
+++ b/bundle/Controller/WebhookController.php
@@ -68,7 +68,7 @@ final class WebhookController extends AbstractController
                     throw new BadRequestHttpException('Invalid request');
                 }
 
-                $this->contentful->refreshContentfulEntry($remoteEntry);
+                $this->contentful->refreshContentfulEntry($remoteEntry, $client);
 
                 break;
             case self::ENTRY_UNPUBLISH:

--- a/bundle/Resources/config/default_settings.yaml
+++ b/bundle/Resources/config/default_settings.yaml
@@ -1,2 +1,4 @@
 parameters:
     netgen_layouts.contentful.cache_dir: '%kernel.cache_dir%/contentful/'
+    netgen_layouts.contentful.routing.content_types: []
+

--- a/bundle/Resources/config/services/services.yaml
+++ b/bundle/Resources/config/services/services.yaml
@@ -8,6 +8,7 @@ services:
             - "@doctrine.orm.entity_manager"
             - "@filesystem"
             - "%netgen_layouts.contentful.cache_dir%"
+            - "%netgen_layouts.contentful.routing.content_types%"
 
     netgen_layouts.contentful.command.sync:
         class: Netgen\Bundle\LayoutsContentfulBundle\Command\SyncCommand
@@ -16,6 +17,15 @@ services:
               - "@filesystem"
         tags:
               - { name: console.command, command: contentful:sync }
+
+    netgen_layouts.contentful.command.routes:
+        class: Netgen\Bundle\LayoutsContentfulBundle\Command\RoutesCommand
+        arguments:
+              - "@netgen_layouts.contentful.service"
+              - "@filesystem"
+              - "@doctrine.orm.entity_manager"
+        tags:
+              - { name: console.command, command: contentful:routes }
 
     netgen_layouts.contentful.entry_slugger.configurable:
         class: Netgen\Layouts\Contentful\Routing\EntrySlugger\Configurable

--- a/lib/Routing/ContentfulEnhancer.php
+++ b/lib/Routing/ContentfulEnhancer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Netgen\Layouts\Contentful\Routing;
 
+use Netgen\Layouts\Contentful\Entity\ContentfulEntry;
 use Netgen\Layouts\Contentful\Service\Contentful;
 use Symfony\Cmf\Component\Routing\Enhancer\RouteEnhancerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,7 +28,11 @@ final class ContentfulEnhancer implements RouteEnhancerInterface
      */
     public function enhance(array $defaults, Request $request): array
     {
-        $defaults['_content'] = $this->contentful->loadContentfulEntry($defaults['_route']);
+        $contentClass = explode(':', $defaults['_content_id'])[0];
+
+        if ($contentClass == ContentfulEntry::class) {
+            $defaults['_content'] = $this->contentful->loadContentfulEntry($defaults['_route']);
+        }
 
         return $defaults;
     }

--- a/lib/Routing/ContentfulEnhancer.php
+++ b/lib/Routing/ContentfulEnhancer.php
@@ -30,7 +30,7 @@ final class ContentfulEnhancer implements RouteEnhancerInterface
     {
         $contentClass = explode(':', $defaults['_content_id'])[0];
 
-        if ($contentClass == ContentfulEntry::class) {
+        if ($contentClass === ContentfulEntry::class) {
             $defaults['_content'] = $this->contentful->loadContentfulEntry($defaults['_route']);
         }
 

--- a/lib/Service/Contentful.php
+++ b/lib/Service/Contentful.php
@@ -54,7 +54,7 @@ final class Contentful
     private $cacheDir;
 
     /**
-     * @var array
+     * @var array<string>
      */
     private $routeContentTypes;
 
@@ -266,10 +266,11 @@ final class Contentful
             $this->entityManager->flush();
             $contentfulEntry->reviveRemoteEntry($client);
 
-            if (empty($this->routeContentTypes) || in_array($contentfulEntry->getContentType()->getId(), $this->routeContentTypes, true)) {
+            if (count($this->routeContentTypes) < 1 || in_array($contentfulEntry->getContentType()->getId(), $this->routeContentTypes, true)) {
                 // if slug has changed create a 301 redirect
                 $currentSlug = $this->entrySlugger->getSlug($contentfulEntry);
                 if ($currentSlug !== $savedCurrentSlug) {
+                    /** @var Route $route */
                     $route = $contentfulEntry->getRoutes()[0];
                     $route->setStaticPrefix($currentSlug);
                     $this->entityManager->persist($route);
@@ -334,7 +335,7 @@ final class Contentful
     /**
      * Deletes all redirects for provided entry.
      */
-    public function deleteRedirects(ContentfulEntry $contentfulEntry)
+    public function deleteRedirects(ContentfulEntry $contentfulEntry): void
     {
         $contentfulEntryRoute = $contentfulEntry->getRoutes()[0];
 
@@ -453,7 +454,7 @@ final class Contentful
         $contentfulEntry->setJson((string) json_encode($remoteEntry));
         $this->entityManager->persist($contentfulEntry);
 
-        if (empty($this->routeContentTypes) || in_array($contentfulEntry->getContentType()->getId(), $this->routeContentTypes, true)) {
+        if (count($this->routeContentTypes) < 1 || in_array($contentfulEntry->getContentType()->getId(), $this->routeContentTypes, true)) {
             $this->buildRoute($id, $contentfulEntry);
         }
 
@@ -488,7 +489,7 @@ final class Contentful
     /**
      * Builds a route for an Entry, n.
      */
-    private function buildRoute(string $id, ContentfulEntry $contentfulEntry)
+    private function buildRoute(string $id, ContentfulEntry $contentfulEntry): Route
     {
         $route = new Route();
         $route->setName($id);
@@ -504,7 +505,7 @@ final class Contentful
     /**
      * Builds a Redirect.
      */
-    private function buildRedirect(string $redirectSlug, ContentfulEntry $contentfulEntry)
+    private function buildRedirect(string $redirectSlug, ContentfulEntry $contentfulEntry): Route
     {
         $contentfulEntryRoute = $contentfulEntry->getRoutes()[0];
         $existingRedirectRouteDocs = $this->entityManager->getRepository(RedirectRoute::class)->findBy(['routeTarget' => $contentfulEntryRoute]);

--- a/lib/Service/Contentful.php
+++ b/lib/Service/Contentful.php
@@ -60,6 +60,7 @@ final class Contentful
 
     /**
      * @param \Contentful\Delivery\Client\ClientInterface[] $clients
+     * @param array<string> $routeContentTypes
      */
     public function __construct(
         array $clients,


### PR DESCRIPTION
- redirects for old slugs (usually happens when Contentful entry name changes)
- console command to list all routes and remove redirects
- generate urls only for configured content types
- few bug fixes