### PR TITLE
Handling sub-items being Entry instances

### DIFF
--- a/lib/Block/BlockDefinition/Handler/EntryFieldHandler.php
+++ b/lib/Block/BlockDefinition/Handler/EntryFieldHandler.php
@@ -188,10 +188,18 @@ final class EntryFieldHandler extends BlockDefinitionHandler
                 $fieldType = ContentfulEntryField::TYPE_ENTRIES;
 
                 foreach ($innerField as $subField) {
+                    if ($subField instanceof Entry) {
+                        $type = $subField->getType();
+                        $id = $subField->getId();
+                    } else {
+                        $type = $subField['sys']['linkType'];
+                        $id = $subField['sys']['id'];
+                    }
+                    
                     if ($subField['sys']['linkType'] === 'Entry') {
-                        $fieldValues[] = $this->loadEntry($entry->getSpace(), $subField['sys']['id']);
+                        $fieldValues[] = $this->loadEntry($entry->getSpace(), $id);
                     } elseif ($subField['sys']['linkType'] === 'Asset') {
-                        $fieldValues[] = $this->loadAsset($entry->getSpace(), $subField['sys']['id']);
+                        $fieldValues[] = $this->loadAsset($entry->getSpace(), $id);
                         $fieldType = ContentfulEntryField::TYPE_ASSETS;
                     }
                 }


### PR DESCRIPTION
Hi!

I'm not really sure what's going on, but this fixes an issue I'm having.

A) On contentful, I have a "many references" field where I select related contentful entries 

<img width="794" alt="Screen Shot 2022-10-27 at 9 32 51 AM" src="https://user-images.githubusercontent.com/121003/198298668-dd5b8c7c-083d-4d77-a03d-2dd2ef4357eb.png">

B) On layouts, I try to render this as a "Contentful Entry Field" using a "View Type" of "Referenced Entries" 

C) When it loads, it doesn't work (it renders the `contentful.field_not_compatible` string) because the `ContentfulEntryField.type` is set to `array` instead of `entries`.

I tracked the problem down to the chnaged code. I'm not sure how it worked previously, but in my situation, `$subField` is an instance of `Entry`.

<img width="363" alt="Screen Shot 2022-10-27 at 9 30 31 AM" src="https://user-images.githubusercontent.com/121003/198299496-c809dd44-36c5-44d7-85f6-a07b7dd35fc3.png">

And so, calling `$entry['sys']` uses the `offsetGet` on that class to try to read a "field" called `sys`... and there is none. If I allow the exception to be thrown instead of hidden (i.e. on line 212 of this class, replace `// Do nothing` with `throw $t`, then I see:

<img width="981" alt="Screen Shot 2022-10-27 at 9 29 42 AM" src="https://user-images.githubusercontent.com/121003/198299438-edae2d2b-fbc2-4243-80c8-9fd0b2c39a47.png">

The fix is pretty simple - calling `$entry->getType()` seems to return the correct "type". I just have no idea why the old code seemed to work before... or what repercussions this might have. However, I tried to add the safest code possible: if `$subField` is an instance of `Entry`, I can't see how `$subField['sys']` would ever work (as this tries to read a field called `sys`) and so this seems like it won't break anything existing.

Cheers!